### PR TITLE
Fix links to note-* repo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ For details on contributions we accept and the process for contributing, see our
 
 For Notecard SDKs and Libraries, see:
 
-* [note-c](note-c) for Standard C support
-* [note-go](note-go) for Go
-* [note-python](note-python) for Python
+* [note-c][note-c] for Standard C support
+* [note-go][note-go] for Go
+* [note-python][note-python] for Python
 
 ## To learn more about Blues Wireless, the Notecard and Notehub, see:
 


### PR DESCRIPTION
Fixed syntax error in reference links for 
 - note-c
 - note-go
 - note-python

changed use of () to [] when referencing links